### PR TITLE
Fix case sensitive name

### DIFF
--- a/src/main/java/seedu/address/model/name/Name.java
+++ b/src/main/java/seedu/address/model/name/Name.java
@@ -55,7 +55,8 @@ public class Name {
         }
 
         Name otherName = (Name) other;
-        return fullName.equals(otherName.fullName);
+
+        return fullName.toLowerCase().equals(otherName.fullName.toLowerCase());
     }
 
     @Override


### PR DESCRIPTION
Fixed case sensitive name in equals function 
- names with different casing but same characters will be detected the same and throw error