### PR TITLE
Fix bug in link and unlink command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/event/LinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/LinkCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
@@ -34,7 +35,7 @@ public class LinkCommand extends Command {
             + PREFIX_EVENT + "NUS Career Fair 2023 "
             + PREFIX_CONTACT + "John Doe";
 
-    public static final String MESSAGE_SUCCESS = "Linked contact: %1$s to event: %2$s";
+    public static final String MESSAGE_SUCCESS = "Linked contact(s): %1$s to event: %2$s";
     public static final String MESSAGE_NO_SUCH_EVENT = "The event: %1$s does not exist in the event list. "
             + "Please add it in first.";
     public static final String MESSAGE_NO_SUCH_CONTACT = "The contact: %1$s does not exist in JobFestGo. "
@@ -57,14 +58,25 @@ public class LinkCommand extends Command {
         requireNonNull(model);
 
         try {
+            Event eventToLink = model.getEvent(eventNameToLink);
+            Set<Contact> contactsToLink = new HashSet<>();
+
             for (Name contactName : contactNameListToLink) {
-                Event eventToLink = model.getEvent(eventNameToLink);
                 Contact contactToLink = model.getContact(contactName);
-                model.linkContactToEvent(contactToLink, eventToLink);
+                if (model.isContactLinkedToEvent(contactToLink, eventToLink)) {
+                    throw new CommandException(
+                            String.format(MESSAGE_LINKED_CONTACT, contactName, eventNameToLink));
+                };
+                contactsToLink.add(contactToLink);
+            }
+
+            for (Contact contact : contactsToLink) {
+                eventToLink = model.getEvent(eventNameToLink);
+                model.linkContactToEvent(contact, eventToLink);
             }
 
             // Get the event after linking contact.
-            Event eventToLink = model.getEvent(eventNameToLink);
+            eventToLink = model.getEvent(eventNameToLink);
 
             // Update the respective filtered lists to show the components within the event
             // Flow of command should be after linking a contact to an event,

--- a/src/main/java/seedu/address/logic/commands/event/UnlinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/UnlinkCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
@@ -34,7 +35,7 @@ public class UnlinkCommand extends Command {
             + PREFIX_EVENT + "NUS Career Fair 2023 "
             + PREFIX_CONTACT + "John Doe";
 
-    public static final String MESSAGE_SUCCESS = "Unlinked contact: %1$s from event: %2$s";
+    public static final String MESSAGE_SUCCESS = "Unlinked contact(s): %1$s from event: %2$s";
     public static final String MESSAGE_NO_SUCH_EVENT = "The event: %1$s does not exist in JobFestGo.";
     public static final String MESSAGE_NO_SUCH_CONTACT = "The contact: %1$s does not exist in JobFestGo.";
     public static final String MESSAGE_UNLINKED_CONTACT = "The contact: %1$s is not linked to the event: %2$s";
@@ -55,13 +56,24 @@ public class UnlinkCommand extends Command {
         requireNonNull(model);
 
         try {
+            Event eventToUnlink = model.getEvent(eventNameToUnlink);
+            Set<Contact> contactsToUnlink = new HashSet<>();
+
             for (Name contactName : contactNameListToUnlink) {
-                Event eventToUnlink = model.getEvent(eventNameToUnlink);
                 Contact contactToUnlink = model.getContact(contactName);
-                model.unlinkContactFromEvent(contactToUnlink, eventToUnlink);
+                if (!model.isContactLinkedToEvent(contactToUnlink, eventToUnlink)) {
+                    throw new CommandException(
+                            String.format(MESSAGE_UNLINKED_CONTACT, contactName, eventNameToUnlink));
+                };
+                contactsToUnlink.add(contactToUnlink);
             }
 
-            Event eventToUnlink = model.getEvent(eventNameToUnlink);
+            for (Contact contact : contactsToUnlink) {
+                eventToUnlink = model.getEvent(eventNameToUnlink);
+                model.unlinkContactFromEvent(contact, eventToUnlink);
+            }
+
+            eventToUnlink = model.getEvent(eventNameToUnlink);
             model.updateFilteredContactList(new ContactIsInEventPredicate(eventToUnlink));
             model.updateFilteredTaskList(new TaskIsInEventPredicate(eventToUnlink));
 

--- a/src/main/java/seedu/address/model/JobFestGo.java
+++ b/src/main/java/seedu/address/model/JobFestGo.java
@@ -247,6 +247,13 @@ public class JobFestGo implements ReadOnlyJobFestGo {
     }
 
     /**
+     * Checks whether the given {@code contact} is linked to the given {@code event}.
+     */
+    public boolean isContactLinkedToEvent(Contact contact, Event event) {
+        return events.isContactLinkedToEvent(contact, event);
+    }
+
+    /**
      * Links the given {@code contact} to the given {@code event}.
      */
     public void linkContactToEvent(Contact contact, Event event) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -169,6 +169,11 @@ public interface Model {
     void setEvent(Event target, Event editedEvent);
 
     /**
+     * Checks whether the given {@code contact} is linked to the given {@code event}.
+     */
+    boolean isContactLinkedToEvent(Contact contact, Event event);
+
+    /**
      * Links the given {@code contact} to the given {@code event}.
      */
     void linkContactToEvent(Contact contact, Event event);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -189,6 +189,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean isContactLinkedToEvent(Contact contact, Event event) {
+        requireAllNonNull(contact, event);
+        return jobFestGo.isContactLinkedToEvent(contact, event);
+    }
+
+    @Override
     public void linkContactToEvent(Contact contact, Event event) {
         requireAllNonNull(contact, event);
         jobFestGo.linkContactToEvent(contact, event);

--- a/src/main/java/seedu/address/model/event/UniqueEventList.java
+++ b/src/main/java/seedu/address/model/event/UniqueEventList.java
@@ -56,6 +56,13 @@ public class UniqueEventList implements Iterable<Event> {
     }
 
     /**
+     * Checks whether a contact is linked to the given event.
+     */
+    public boolean isContactLinkedToEvent(Contact contact, Event event) {
+        return event.isLinkedToContact(contact);
+    }
+
+    /**
      * Links a contact to the given event.
      * @throws EventIsAlreadyLinkedToContactException If the given contact is
      *     already linked to the event.

--- a/src/test/java/seedu/address/logic/commands/contact/AddContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/AddContactCommandTest.java
@@ -254,6 +254,11 @@ public class AddContactCommandTest {
         }
 
         @Override
+        public boolean isContactLinkedToEvent(Contact contact, Event event) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void linkContactToEvent(Contact contact, Event event) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/event/AddEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/event/AddEventCommandTest.java
@@ -240,6 +240,11 @@ public class AddEventCommandTest {
         }
 
         @Override
+        public boolean isContactLinkedToEvent(Contact contact, Event event) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void linkContactToEvent(Contact contact, Event event) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/event/UnlinkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/event/UnlinkCommandTest.java
@@ -9,9 +9,9 @@ import static seedu.address.testutil.contact.TypicalContacts.ALICE;
 import static seedu.address.testutil.contact.TypicalContacts.BENSON;
 import static seedu.address.testutil.contact.TypicalContacts.BOB;
 import static seedu.address.testutil.contact.TypicalContacts.CARL;
-import static seedu.address.testutil.contact.TypicalContacts.getTypicalJobFestGo;
 import static seedu.address.testutil.event.TypicalEvents.JOBFEST;
 import static seedu.address.testutil.event.TypicalEvents.NTU;
+import static seedu.address.testutil.event.TypicalEvents.getTypicalJobFestGo;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -38,14 +38,12 @@ public class UnlinkCommandTest {
     @Test
     public void execute_validSingleContact_success() {
         Set<Name> contactNameList = new HashSet<>();
-        contactNameList.add(CARL.getName());
-        model.addEvent(JOBFEST);
-        expectedModel.addEvent(JOBFEST);
+        contactNameList.add(ALICE.getName());
         UnlinkCommand command = new UnlinkCommand(JOBFEST.getName(), contactNameList);
-        assertEquals(JOBFEST, model.getEvent(JOBFEST.getName()));
-        String expectedNameList = "[" + CARL.getName() + "]";
+        String expectedNameList = "[" + ALICE.getName() + "]";
         String expectedMessage = String.format(UnlinkCommand.MESSAGE_SUCCESS, expectedNameList, JOBFEST.getName());
-        expectedModel.linkContactToEvent(CARL, JOBFEST);
+        Event unlinkedEvent = new EventBuilder(JOBFEST).withEventContacts(BOB).build();
+        expectedModel.unlinkContactFromEvent(ALICE, JOBFEST);
 
         try {
             command.execute(expectedModel);
@@ -54,20 +52,18 @@ public class UnlinkCommandTest {
         }
 
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(unlinkedEvent, model.getEvent(JOBFEST.getName()));
     }
 
     @Test
     public void execute_validMultipleContacts_success() {
-        Event expectedEvent = new EventBuilder().withName("JobFest 2023")
-                .withDate("2023-12-12")
-                .withEventAddress("3 Temasek Blvd, Singapore 038983")
-                .withEventContacts(ALICE, BOB, CARL, BENSON)
-                .build();
         Set<Name> contactNameList = new HashSet<>();
-        contactNameList.add(CARL.getName());
-        contactNameList.add(BENSON.getName());
-        model.addEvent(JOBFEST);
-        expectedModel.addEvent(expectedEvent);
+        contactNameList.add(ALICE.getName());
+        contactNameList.add(BOB.getName());
+        expectedModel.unlinkContactFromEvent(ALICE, JOBFEST);
+        Event unlinkedEvent = new EventBuilder(JOBFEST).withEventContacts(BOB).build();
+        expectedModel.unlinkContactFromEvent(BOB, unlinkedEvent);
+        Event expectedEvent = new EventBuilder(JOBFEST).withEventContacts().build();
         UnlinkCommand command = new UnlinkCommand(JOBFEST.getName(), contactNameList);
 
         try {
@@ -76,41 +72,32 @@ public class UnlinkCommandTest {
             return;
         }
 
-        String expectedNameList = "[" + CARL.getName() + ", " + BENSON.getName() + "]";
+        String expectedNameList = "[" + ALICE.getName() + ", " + BOB.getName() + "]";
         String expectedMessage = String.format(UnlinkCommand.MESSAGE_SUCCESS, expectedNameList, JOBFEST.getName());
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(expectedEvent, model.getEvent(JOBFEST.getName()));
     }
 
     @Test
-    public void execute_eventAlreadyLinkedToContact_throwsCommandException() {
-        Event event = new EventBuilder().withName("JobFest 2023")
-                .withDate("2023-12-12")
-                .withEventAddress("3 Temasek Blvd, Singapore 038983")
-                .withEventContacts(ALICE, BOB)
-                .build();
-
+    public void execute_eventNotLinkedToContact_throwsCommandException() {
         Set<Name> contactNameList = new HashSet<>();
-        contactNameList.add(ALICE.getName());
+        contactNameList.add(BENSON.getName());
+        model.addContact(BENSON);
 
-        UnlinkCommand command = new UnlinkCommand(event.getName(), contactNameList);
-        String expectedMessage = String.format(UnlinkCommand.MESSAGE_LINKED_CONTACT, ALICE.getName(), event.getName());
-        model.addEvent(event);
+        UnlinkCommand command = new UnlinkCommand(JOBFEST.getName(), contactNameList);
+        String expectedMessage = String.format(UnlinkCommand.MESSAGE_UNLINKED_CONTACT,
+                BENSON.getName(), JOBFEST.getName());
         assertCommandFailure(command, model, expectedMessage);
     }
 
     @Test
     public void execute_eventNotInTheList_throwsCommandException() {
-        Event event = new EventBuilder().withName("JobFest 2023")
-                .withDate("2023-12-12")
-                .withEventAddress("3 Temasek Blvd, Singapore 038983")
-                .withEventContacts(ALICE, BOB)
-                .build();
-
         Set<Name> contactNameList = new HashSet<>();
         contactNameList.add(ALICE.getName());
+        model.deleteEvent(JOBFEST);
 
-        UnlinkCommand command = new UnlinkCommand(event.getName(), contactNameList);
-        String expectedMessage = String.format(UnlinkCommand.MESSAGE_NO_SUCH_EVENT, event.getName());
+        UnlinkCommand command = new UnlinkCommand(JOBFEST.getName(), contactNameList);
+        String expectedMessage = String.format(UnlinkCommand.MESSAGE_NO_SUCH_EVENT, JOBFEST.getName());
         assertCommandFailure(command, model, expectedMessage);
     }
 

--- a/src/test/java/seedu/address/logic/commands/event/UnlinkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/event/UnlinkCommandTest.java
@@ -1,0 +1,186 @@
+package seedu.address.logic.commands.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.contact.TypicalContacts.ALICE;
+import static seedu.address.testutil.contact.TypicalContacts.BENSON;
+import static seedu.address.testutil.contact.TypicalContacts.BOB;
+import static seedu.address.testutil.contact.TypicalContacts.CARL;
+import static seedu.address.testutil.contact.TypicalContacts.getTypicalJobFestGo;
+import static seedu.address.testutil.event.TypicalEvents.JOBFEST;
+import static seedu.address.testutil.event.TypicalEvents.NTU;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.contact.Contact;
+import seedu.address.model.event.Event;
+import seedu.address.model.name.Name;
+import seedu.address.testutil.contact.ContactBuilder;
+import seedu.address.testutil.event.EventBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code UnlinkCommand}.
+ */
+public class UnlinkCommandTest {
+    private Model model = new ModelManager(getTypicalJobFestGo(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalJobFestGo(), new UserPrefs());
+
+    @Test
+    public void execute_validSingleContact_success() {
+        Set<Name> contactNameList = new HashSet<>();
+        contactNameList.add(CARL.getName());
+        model.addEvent(JOBFEST);
+        expectedModel.addEvent(JOBFEST);
+        UnlinkCommand command = new UnlinkCommand(JOBFEST.getName(), contactNameList);
+        assertEquals(JOBFEST, model.getEvent(JOBFEST.getName()));
+        String expectedNameList = "[" + CARL.getName() + "]";
+        String expectedMessage = String.format(UnlinkCommand.MESSAGE_SUCCESS, expectedNameList, JOBFEST.getName());
+        expectedModel.linkContactToEvent(CARL, JOBFEST);
+
+        try {
+            command.execute(expectedModel);
+        } catch (CommandException ce) {
+            return;
+        }
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validMultipleContacts_success() {
+        Event expectedEvent = new EventBuilder().withName("JobFest 2023")
+                .withDate("2023-12-12")
+                .withEventAddress("3 Temasek Blvd, Singapore 038983")
+                .withEventContacts(ALICE, BOB, CARL, BENSON)
+                .build();
+        Set<Name> contactNameList = new HashSet<>();
+        contactNameList.add(CARL.getName());
+        contactNameList.add(BENSON.getName());
+        model.addEvent(JOBFEST);
+        expectedModel.addEvent(expectedEvent);
+        UnlinkCommand command = new UnlinkCommand(JOBFEST.getName(), contactNameList);
+
+        try {
+            command.execute(expectedModel);
+        } catch (CommandException ce) {
+            return;
+        }
+
+        String expectedNameList = "[" + CARL.getName() + ", " + BENSON.getName() + "]";
+        String expectedMessage = String.format(UnlinkCommand.MESSAGE_SUCCESS, expectedNameList, JOBFEST.getName());
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_eventAlreadyLinkedToContact_throwsCommandException() {
+        Event event = new EventBuilder().withName("JobFest 2023")
+                .withDate("2023-12-12")
+                .withEventAddress("3 Temasek Blvd, Singapore 038983")
+                .withEventContacts(ALICE, BOB)
+                .build();
+
+        Set<Name> contactNameList = new HashSet<>();
+        contactNameList.add(ALICE.getName());
+
+        UnlinkCommand command = new UnlinkCommand(event.getName(), contactNameList);
+        String expectedMessage = String.format(UnlinkCommand.MESSAGE_LINKED_CONTACT, ALICE.getName(), event.getName());
+        model.addEvent(event);
+        assertCommandFailure(command, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_eventNotInTheList_throwsCommandException() {
+        Event event = new EventBuilder().withName("JobFest 2023")
+                .withDate("2023-12-12")
+                .withEventAddress("3 Temasek Blvd, Singapore 038983")
+                .withEventContacts(ALICE, BOB)
+                .build();
+
+        Set<Name> contactNameList = new HashSet<>();
+        contactNameList.add(ALICE.getName());
+
+        UnlinkCommand command = new UnlinkCommand(event.getName(), contactNameList);
+        String expectedMessage = String.format(UnlinkCommand.MESSAGE_NO_SUCH_EVENT, event.getName());
+        assertCommandFailure(command, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_contactNotInTheList_throwsCommandException() {
+        Event event = new EventBuilder().withName("JobFest 2023")
+                .withDate("2023-12-12")
+                .withEventAddress("3 Temasek Blvd, Singapore 038983")
+                .withEventContacts(ALICE, BOB)
+                .build();
+        Contact contact = new ContactBuilder().withName("Li Mei")
+                .withAddress("123, East Coast Ave 6, #08-382").withEmail("limei@example.com")
+                .withPhone("97292222")
+                .withTags("friends").build();
+
+        Set<Name> contactNameList = new HashSet<>();
+        contactNameList.add(contact.getName());
+
+        UnlinkCommand command = new UnlinkCommand(event.getName(), contactNameList);
+        model.addEvent(event);
+        String expectedMessage = String.format(UnlinkCommand.MESSAGE_NO_SUCH_CONTACT, contact.getName());
+        assertCommandFailure(command, model, expectedMessage);
+    }
+
+    @Test
+    public void equals() {
+        Set<Name> firstContactNameList = new HashSet<>();
+        Set<Name> secondContactNameList = new HashSet<>();
+        firstContactNameList.add(CARL.getName());
+        secondContactNameList.add(BENSON.getName());
+
+        UnlinkCommand firstUnlinkCommand = new UnlinkCommand(JOBFEST.getName(), firstContactNameList);
+        UnlinkCommand secondUnlinkCommand = new UnlinkCommand(NTU.getName(), secondContactNameList);
+        UnlinkCommand thirdUnlinkCommand = new UnlinkCommand(JOBFEST.getName(), secondContactNameList);
+        UnlinkCommand fourthUnlinkCommand = new UnlinkCommand(NTU.getName(), firstContactNameList);
+
+        // same object -> returns true
+        assertTrue(firstUnlinkCommand.equals(firstUnlinkCommand));
+
+        // same values -> returns true
+        UnlinkCommand firstUnlinkCommandCopy = new UnlinkCommand(JOBFEST.getName(), firstContactNameList);
+        assertTrue(firstUnlinkCommand.equals(firstUnlinkCommandCopy));
+
+        // different types -> returns false
+        assertFalse(firstUnlinkCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(firstUnlinkCommand.equals(null));
+
+        // different event and different contact -> returns false
+        assertFalse(firstUnlinkCommand.equals(secondUnlinkCommand));
+
+        // same event but different contact -> returns false
+        assertFalse(firstUnlinkCommand.equals(thirdUnlinkCommand));
+
+        // same contact but different event -> returns false
+        assertFalse(firstUnlinkCommand.equals(fourthUnlinkCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Set<Name> contactNameList = new HashSet<>();
+        contactNameList.add(CARL.getName());
+        contactNameList.add(BENSON.getName());
+
+        UnlinkCommand command = new UnlinkCommand(JOBFEST.getName(), contactNameList);
+
+        String expected = UnlinkCommand.class.getCanonicalName()
+                + "{eventToLink=" + JOBFEST.getName() + ", "
+                + "contactToLink=[" + CARL.getName() + ", " + BENSON.getName() + "]}";
+        assertEquals(expected, command.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/tag/AddTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/tag/AddTagCommandTest.java
@@ -225,6 +225,11 @@ public class AddTagCommandTest {
         }
 
         @Override
+        public boolean isContactLinkedToEvent(Contact contact, Event event) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void linkContactToEvent(Contact contact, Event event) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/tag/DeleteTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/tag/DeleteTagCommandTest.java
@@ -237,6 +237,11 @@ public class DeleteTagCommandTest {
         }
 
         @Override
+        public boolean isContactLinkedToEvent(Contact contact, Event event) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void linkContactToEvent(Contact contact, Event event) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/task/AddTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/AddTaskCommandTest.java
@@ -250,6 +250,11 @@ public class AddTaskCommandTest {
         }
 
         @Override
+        public boolean isContactLinkedToEvent(Contact contact, Event event) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void linkContactToEvent(Contact contact, Event event) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/task/AddTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/AddTaskCommandTest.java
@@ -72,7 +72,7 @@ public class AddTaskCommandTest {
     }
 
     @Test
-    public void execute_duplicateTag_throwsCommandException() {
+    public void execute_duplicateTask_throwsCommandException() {
 
         Task validTask = new TaskBuilder().withEvent(NTU).build();
         ModelStub modelStub = new ModelStubWithTask(validTask);

--- a/src/test/java/seedu/address/logic/commands/task/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/DeleteTaskCommandTest.java
@@ -1,0 +1,100 @@
+package seedu.address.logic.commands.task;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.task.AddTaskCommand.MESSAGE_DUPLICATE_TASK;
+import static seedu.address.logic.commands.task.DeleteTaskCommand.MESSAGE_MISSING_TASK;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.event.TypicalEvents.JOBFEST;
+import static seedu.address.testutil.event.TypicalEvents.NTU;
+import static seedu.address.testutil.event.TypicalEvents.getTypicalJobFestGo;
+import static seedu.address.testutil.task.TypicalTasks.BOOK_VENUE;
+import static seedu.address.testutil.task.TypicalTasks.ORDER_FOOD;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.contact.DeleteContactCommand;
+import seedu.address.logic.commands.event.DeleteEventCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.tag.DeleteTagCommand;
+import seedu.address.logic.commands.tag.DeleteTagCommandTest;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.event.Event;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.task.Task;
+import seedu.address.testutil.task.TaskBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code DeleteTaskCommand}.
+ */
+public class DeleteTaskCommandTest {
+    private Model model = new ModelManager(getTypicalJobFestGo(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalJobFestGo(), new UserPrefs());
+
+    /**
+     * Tests when task to be deleted is valid.
+     */
+    @Test
+    public void execute_validTask_success() {
+        model.addTask(BOOK_VENUE);
+        expectedModel.addTask(BOOK_VENUE);
+        DeleteTaskCommand command = new DeleteTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
+        expectedModel.deleteTask(BOOK_VENUE.getDescription(), JOBFEST.getName());
+        String expectedMessage = String.format(DeleteTaskCommand.MESSAGE_SUCCESS,
+                BOOK_VENUE.getDescription(), JOBFEST.getName());
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    /**
+     * Tests when task to be deleted does not exist.
+     */
+    @Test
+    public void execute_taskDoesNotExist_throwsException() {
+        model.addTask(ORDER_FOOD);
+        DeleteTaskCommand command = new DeleteTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
+        assertThrows(CommandException.class, MESSAGE_MISSING_TASK, () -> command.execute(model));
+    }
+
+    /**
+     * Tests when there is a task with same description as that of the one to be deleted
+     * while they are associated to different events.
+     */
+    @Test
+    public void execute_taskWithSameDescriptionButDifferentEvent_throwsException() {
+        Task TaskWithSameDescription = new TaskBuilder().withEvent(NTU)
+                .withDate("2023-12-10")
+                .withDescription("Book venue")
+                .build();
+        model.addTask(TaskWithSameDescription);
+        DeleteTaskCommand command = new DeleteTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
+        assertThrows(CommandException.class, MESSAGE_MISSING_TASK, () -> command.execute(model));
+    }
+
+    /**
+     * Tests to see that DeleteTagCommands with the same tag is the same.
+     */
+    @Test
+    public void equals_sameTag() {
+        Tag test = new Tag("vendor");
+        DeleteTagCommandTest.ModelStubWithTags testModel = new DeleteTagCommandTest.ModelStubWithTags();
+        testModel.addTag(test);
+        DeleteTagCommand same1 = new DeleteTagCommand(test);
+        DeleteTagCommand same2 = new DeleteTagCommand(test);
+        DeleteContactCommand diffCommand = new DeleteContactCommand(INDEX_FIRST);
+        assertEquals(same1, same2);
+        assertEquals(same1, same1);
+        assertFalse(same1.equals(diffCommand));
+    }
+
+    @Test
+    public void toString_testEqual() {
+        DeleteTagCommand test = new DeleteTagCommand(new Tag("vendor"));
+        assertEquals(test.toString(), test.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/task/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/DeleteTaskCommandTest.java
@@ -66,7 +66,7 @@ public class DeleteTaskCommandTest {
         DeleteTaskCommand command = new DeleteTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
         assertThrows(CommandException.class, MESSAGE_MISSING_TASK, () -> command.execute(model));
     }
-    
+
     @Test
     public void equals() {
         DeleteTaskCommand firstDeleteTaskCommand =

--- a/src/test/java/seedu/address/logic/commands/task/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/DeleteTaskCommandTest.java
@@ -58,11 +58,11 @@ public class DeleteTaskCommandTest {
      */
     @Test
     public void execute_taskWithSameDescriptionButDifferentEvent_throwsException() {
-        Task TaskWithSameDescription = new TaskBuilder().withEvent(NTU)
+        Task taskWithSameDescription = new TaskBuilder().withEvent(NTU)
                 .withDate("2023-12-10")
                 .withDescription("Book venue")
                 .build();
-        model.addTask(TaskWithSameDescription);
+        model.addTask(taskWithSameDescription);
         DeleteTaskCommand command = new DeleteTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
         assertThrows(CommandException.class, MESSAGE_MISSING_TASK, () -> command.execute(model));
     }

--- a/src/test/java/seedu/address/logic/commands/task/MarkTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/MarkTaskCommandTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.task.DeleteTaskCommand.MESSAGE_MISSING_TASK;
+import static seedu.address.logic.commands.task.MarkTaskCommand.MESSAGE_MISSING_TASK;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.event.TypicalEvents.JOBFEST;
 import static seedu.address.testutil.event.TypicalEvents.NTU;
@@ -22,9 +22,9 @@ import seedu.address.model.task.Task;
 import seedu.address.testutil.task.TaskBuilder;
 
 /**
- * Contains integration tests (interaction with the Model) for {@code DeleteTaskCommand}.
+ * Contains integration tests (interaction with the Model) for {@code MarkTaskCommand}.
  */
-public class DeleteTaskCommandTest {
+public class MarkTaskCommandTest {
     private Model model = new ModelManager(getTypicalJobFestGo(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalJobFestGo(), new UserPrefs());
 
@@ -35,9 +35,9 @@ public class DeleteTaskCommandTest {
     public void execute_validTask_success() {
         model.addTask(BOOK_VENUE);
         expectedModel.addTask(BOOK_VENUE);
-        DeleteTaskCommand command = new DeleteTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
+        MarkTaskCommand command = new MarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
         expectedModel.deleteTask(BOOK_VENUE.getDescription(), JOBFEST.getName());
-        String expectedMessage = String.format(DeleteTaskCommand.MESSAGE_SUCCESS,
+        String expectedMessage = String.format(MarkTaskCommand.MESSAGE_SUCCESS,
                 BOOK_VENUE.getDescription(), JOBFEST.getName());
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
     }
@@ -48,7 +48,7 @@ public class DeleteTaskCommandTest {
     @Test
     public void execute_taskDoesNotExist_throwsException() {
         model.addTask(ORDER_FOOD);
-        DeleteTaskCommand command = new DeleteTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
+        MarkTaskCommand command = new MarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
         assertThrows(CommandException.class, MESSAGE_MISSING_TASK, () -> command.execute(model));
     }
 
@@ -63,51 +63,51 @@ public class DeleteTaskCommandTest {
                 .withDescription("Book venue")
                 .build();
         model.addTask(TaskWithSameDescription);
-        DeleteTaskCommand command = new DeleteTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
+        MarkTaskCommand command = new MarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
         assertThrows(CommandException.class, MESSAGE_MISSING_TASK, () -> command.execute(model));
     }
-    
+
     @Test
     public void equals() {
-        DeleteTaskCommand firstDeleteTaskCommand =
-                new DeleteTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
-        DeleteTaskCommand secondDeleteTaskCommand =
-                new DeleteTaskCommand(BOOK_VENUE.getDescription(), NTU.getName());
-        DeleteTaskCommand thirdDeleteTaskCommand =
-                new DeleteTaskCommand(ORDER_FOOD.getDescription(), JOBFEST.getName());
-        DeleteTaskCommand fourthDeleteTaskCommand =
-                new DeleteTaskCommand(ORDER_FOOD.getDescription(), NTU.getName());
+        MarkTaskCommand firstMarkTaskCommand =
+                new MarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
+        MarkTaskCommand secondMarkTaskCommand =
+                new MarkTaskCommand(BOOK_VENUE.getDescription(), NTU.getName());
+        MarkTaskCommand thirdMarkTaskCommand =
+                new MarkTaskCommand(ORDER_FOOD.getDescription(), JOBFEST.getName());
+        MarkTaskCommand fourthMarkTaskCommand =
+                new MarkTaskCommand(ORDER_FOOD.getDescription(), NTU.getName());
 
         // same object -> returns true
-        assertTrue(firstDeleteTaskCommand.equals(firstDeleteTaskCommand));
+        assertTrue(firstMarkTaskCommand.equals(firstMarkTaskCommand));
 
         // same values -> returns true
-        DeleteTaskCommand firstDeleteTaskCommandCopy =
-                new DeleteTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
-        assertTrue(firstDeleteTaskCommand.equals(firstDeleteTaskCommandCopy));
+        MarkTaskCommand firstMarkTaskCommandCopy =
+                new MarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
+        assertTrue(firstMarkTaskCommand.equals(firstMarkTaskCommandCopy));
 
         // different types -> returns false
-        assertFalse(firstDeleteTaskCommand.equals(1));
+        assertFalse(firstMarkTaskCommand.equals(1));
 
         // null -> returns false
-        assertFalse(firstDeleteTaskCommand.equals(null));
+        assertFalse(firstMarkTaskCommand.equals(null));
 
         // different task description and different event name -> returns false
-        assertFalse(firstDeleteTaskCommand.equals(secondDeleteTaskCommand));
+        assertFalse(firstMarkTaskCommand.equals(secondMarkTaskCommand));
 
         // same event name but different task description -> returns false
-        assertFalse(firstDeleteTaskCommand.equals(thirdDeleteTaskCommand));
+        assertFalse(firstMarkTaskCommand.equals(thirdMarkTaskCommand));
 
         // same task description but different event name -> returns false
-        assertFalse(firstDeleteTaskCommand.equals(fourthDeleteTaskCommand));
+        assertFalse(firstMarkTaskCommand.equals(fourthMarkTaskCommand));
     }
 
     @Test
     public void toStringMethod() {
-        DeleteTaskCommand command =
-                new DeleteTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
+        MarkTaskCommand command =
+                new MarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
 
-        String expected = DeleteTaskCommand.class.getCanonicalName()
+        String expected = MarkTaskCommand.class.getCanonicalName()
                 + "{toDelete=" + BOOK_VENUE.getDescription() + ", "
                 + "associatedEvent=" + JOBFEST.getName() + "}";
 

--- a/src/test/java/seedu/address/logic/commands/task/MarkTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/MarkTaskCommandTest.java
@@ -59,11 +59,11 @@ public class MarkTaskCommandTest {
      */
     @Test
     public void execute_taskWithSameDescriptionButDifferentEvent_throwsException() {
-        Task TaskWithSameDescription = new TaskBuilder().withEvent(NTU)
+        Task taskWithSameDescription = new TaskBuilder().withEvent(NTU)
                 .withDate("2023-12-10")
                 .withDescription("Book venue")
                 .build();
-        model.addTask(TaskWithSameDescription);
+        model.addTask(taskWithSameDescription);
         MarkTaskCommand command = new MarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
         assertThrows(CommandException.class, MESSAGE_MISSING_TASK, () -> command.execute(model));
     }

--- a/src/test/java/seedu/address/logic/commands/task/UnmarkTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/UnmarkTaskCommandTest.java
@@ -60,12 +60,12 @@ public class UnmarkTaskCommandTest {
      */
     @Test
     public void execute_taskWithSameDescriptionButDifferentEvent_throwsException() {
-        Task TaskWithSameDescription = new TaskBuilder().withEvent(NTU)
+        Task taskWithSameDescription = new TaskBuilder().withEvent(NTU)
                 .withDate("2023-12-10")
                 .withDescription("Book venue")
                 .withIsCompleted(true)
                 .build();
-        model.addTask(TaskWithSameDescription);
+        model.addTask(taskWithSameDescription);
         UnmarkTaskCommand command = new UnmarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
         assertThrows(CommandException.class, MESSAGE_MISSING_TASK, () -> command.execute(model));
     }

--- a/src/test/java/seedu/address/logic/commands/task/UnmarkTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/UnmarkTaskCommandTest.java
@@ -4,8 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.task.MarkTaskCommand.MESSAGE_COMPLETED_TASK;
-import static seedu.address.logic.commands.task.MarkTaskCommand.MESSAGE_MISSING_TASK;
+import static seedu.address.logic.commands.task.UnmarkTaskCommand.MESSAGE_INCOMPLETED_TASK;
+import static seedu.address.logic.commands.task.UnmarkTaskCommand.MESSAGE_MISSING_TASK;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.event.TypicalEvents.JOBFEST;
 import static seedu.address.testutil.event.TypicalEvents.NTU;
@@ -23,9 +23,9 @@ import seedu.address.model.task.Task;
 import seedu.address.testutil.task.TaskBuilder;
 
 /**
- * Contains integration tests (interaction with the Model) for {@code MarkTaskCommand}.
+ * Contains integration tests (interaction with the Model) for {@code UnmarkTaskCommand}.
  */
-public class MarkTaskCommandTest {
+public class UnmarkTaskCommandTest {
     private Model model = new ModelManager(getTypicalJobFestGo(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalJobFestGo(), new UserPrefs());
 
@@ -35,10 +35,10 @@ public class MarkTaskCommandTest {
     @Test
     public void execute_validTask_success() {
         Task markedTask = new TaskBuilder(BOOK_VENUE).withIsCompleted(true).build();
-        model.addTask(BOOK_VENUE);
-        expectedModel.addTask(markedTask);
-        MarkTaskCommand command = new MarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
-        String expectedMessage = String.format(MarkTaskCommand.MESSAGE_SUCCESS,
+        model.addTask(markedTask);
+        expectedModel.addTask(BOOK_VENUE);
+        UnmarkTaskCommand command = new UnmarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
+        String expectedMessage = String.format(UnmarkTaskCommand.MESSAGE_SUCCESS,
                 BOOK_VENUE.getDescription(), JOBFEST.getName());
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
     }
@@ -48,8 +48,9 @@ public class MarkTaskCommandTest {
      */
     @Test
     public void execute_taskDoesNotExist_throwsException() {
-        model.addTask(ORDER_FOOD);
-        MarkTaskCommand command = new MarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
+        Task markedTask = new TaskBuilder(ORDER_FOOD).withIsCompleted(true).build();
+        model.addTask(markedTask);
+        UnmarkTaskCommand command = new UnmarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
         assertThrows(CommandException.class, MESSAGE_MISSING_TASK, () -> command.execute(model));
     }
 
@@ -62,65 +63,65 @@ public class MarkTaskCommandTest {
         Task TaskWithSameDescription = new TaskBuilder().withEvent(NTU)
                 .withDate("2023-12-10")
                 .withDescription("Book venue")
+                .withIsCompleted(true)
                 .build();
         model.addTask(TaskWithSameDescription);
-        MarkTaskCommand command = new MarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
+        UnmarkTaskCommand command = new UnmarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
         assertThrows(CommandException.class, MESSAGE_MISSING_TASK, () -> command.execute(model));
     }
 
     /**
-     * Tests when the task is already marked as completed.
+     * Tests when the task has not been marked as completed.
      */
     @Test
-    public void execute_taskIsCompleted_throwsException() {
-        Task markedTask = new TaskBuilder(BOOK_VENUE).withIsCompleted(true).build();
-        model.addTask(markedTask);
-        MarkTaskCommand command = new MarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
-        assertThrows(CommandException.class, MESSAGE_COMPLETED_TASK, () -> command.execute(model));
+    public void execute_taskIsNotCompleted_throwsException() {
+        model.addTask(BOOK_VENUE);
+        UnmarkTaskCommand command = new UnmarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
+        assertThrows(CommandException.class, MESSAGE_INCOMPLETED_TASK, () -> command.execute(model));
     }
 
     @Test
     public void equals() {
-        MarkTaskCommand firstMarkTaskCommand =
-                new MarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
-        MarkTaskCommand secondMarkTaskCommand =
-                new MarkTaskCommand(BOOK_VENUE.getDescription(), NTU.getName());
-        MarkTaskCommand thirdMarkTaskCommand =
-                new MarkTaskCommand(ORDER_FOOD.getDescription(), JOBFEST.getName());
-        MarkTaskCommand fourthMarkTaskCommand =
-                new MarkTaskCommand(ORDER_FOOD.getDescription(), NTU.getName());
+        UnmarkTaskCommand firstUnmarkTaskCommand =
+                new UnmarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
+        UnmarkTaskCommand secondUnmarkTaskCommand =
+                new UnmarkTaskCommand(BOOK_VENUE.getDescription(), NTU.getName());
+        UnmarkTaskCommand thirdUnmarkTaskCommand =
+                new UnmarkTaskCommand(ORDER_FOOD.getDescription(), JOBFEST.getName());
+        UnmarkTaskCommand fourthUnmarkTaskCommand =
+                new UnmarkTaskCommand(ORDER_FOOD.getDescription(), NTU.getName());
 
         // same object -> returns true
-        assertTrue(firstMarkTaskCommand.equals(firstMarkTaskCommand));
+        assertTrue(firstUnmarkTaskCommand.equals(firstUnmarkTaskCommand));
 
         // same values -> returns true
-        MarkTaskCommand firstMarkTaskCommandCopy =
-                new MarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
-        assertTrue(firstMarkTaskCommand.equals(firstMarkTaskCommandCopy));
+        UnmarkTaskCommand firstUnmarkTaskCommandCopy =
+                new UnmarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
+        assertTrue(firstUnmarkTaskCommand.equals(firstUnmarkTaskCommandCopy));
 
         // different types -> returns false
-        assertFalse(firstMarkTaskCommand.equals(1));
+        assertFalse(firstUnmarkTaskCommand.equals(1));
 
         // null -> returns false
-        assertFalse(firstMarkTaskCommand.equals(null));
+        assertFalse(firstUnmarkTaskCommand.equals(null));
 
         // different task description and different event name -> returns false
-        assertFalse(firstMarkTaskCommand.equals(secondMarkTaskCommand));
+        assertFalse(firstUnmarkTaskCommand.equals(secondUnmarkTaskCommand));
 
         // same event name but different task description -> returns false
-        assertFalse(firstMarkTaskCommand.equals(thirdMarkTaskCommand));
+        assertFalse(firstUnmarkTaskCommand.equals(thirdUnmarkTaskCommand));
 
         // same task description but different event name -> returns false
-        assertFalse(firstMarkTaskCommand.equals(fourthMarkTaskCommand));
+        assertFalse(firstUnmarkTaskCommand.equals(fourthUnmarkTaskCommand));
     }
 
     @Test
     public void toStringMethod() {
-        MarkTaskCommand command =
-                new MarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
+        UnmarkTaskCommand command =
+                new UnmarkTaskCommand(BOOK_VENUE.getDescription(), JOBFEST.getName());
 
-        String expected = MarkTaskCommand.class.getCanonicalName()
-                + "{toMark=" + BOOK_VENUE.getDescription() + ", "
+        String expected = UnmarkTaskCommand.class.getCanonicalName()
+                + "{toUnmark=" + BOOK_VENUE.getDescription() + ", "
                 + "associatedEvent=" + JOBFEST.getName() + "}";
 
         assertEquals(expected, command.toString());

--- a/src/test/java/seedu/address/logic/parser/JobFestGoParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/JobFestGoParserTest.java
@@ -32,6 +32,7 @@ import seedu.address.logic.commands.contact.ViewContactsCommand;
 import seedu.address.logic.commands.event.AddEventCommand;
 import seedu.address.logic.commands.event.LinkCommand;
 import seedu.address.logic.commands.event.SelectEventCommand;
+import seedu.address.logic.commands.event.UnlinkCommand;
 import seedu.address.logic.commands.event.ViewEventsCommand;
 import seedu.address.logic.commands.tag.AddTagCommand;
 import seedu.address.logic.commands.tag.DeleteTagCommand;
@@ -107,6 +108,17 @@ public class JobFestGoParserTest {
 
         LinkCommand command = (LinkCommand) parser.parseCommand(EventUtil.getLinkCommand(name, contactName));
         assertEquals(new LinkCommand(name, contactNameList), command);
+    }
+
+    @Test
+    public void parseCommand_unlink() throws Exception {
+        Name name = new Name("NUS Career Fair");
+        Name contactName = new Name("Li Mei");
+        Set<Name> contactNameList = new HashSet<>();
+        contactNameList.add(contactName);
+
+        UnlinkCommand command = (UnlinkCommand) parser.parseCommand(EventUtil.getUnlinkCommand(name, contactName));
+        assertEquals(new UnlinkCommand(name, contactNameList), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/event/UnlinkCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/event/UnlinkCommandParserTest.java
@@ -1,0 +1,71 @@
+package seedu.address.logic.parser.event;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.contact.TypicalContacts.BENSON;
+import static seedu.address.testutil.contact.TypicalContacts.CARL;
+import static seedu.address.testutil.event.TypicalEvents.JOBFEST;
+import static seedu.address.testutil.event.TypicalEvents.NTU;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.event.UnlinkCommand;
+import seedu.address.model.name.Name;
+import seedu.address.testutil.event.EventUtil;
+
+public class UnlinkCommandParserTest {
+    private UnlinkCommandParser parser = new UnlinkCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnlinkCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        Set<Name> contactNameList = new HashSet<>();
+        contactNameList.add(CARL.getName());
+        UnlinkCommand expectedUnlinkCommand = new UnlinkCommand(JOBFEST.getName(), contactNameList);
+
+        assertParseSuccess(parser, " " + EventUtil.getName(JOBFEST.getName())
+                + EventUtil.getContactName(CARL.getName()), expectedUnlinkCommand);
+    }
+
+    @Test
+    public void parse_multipleEvents_failure() {
+        assertParseFailure(parser, " " + EventUtil.getName(JOBFEST.getName())
+                        + EventUtil.getName(NTU.getName()) + EventUtil.getContactName(CARL.getName()),
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EVENT));
+    }
+
+    @Test
+    public void parse_multipleContacts_success() {
+        Set<Name> contactNameList = new HashSet<>();
+        contactNameList.add(CARL.getName());
+        contactNameList.add(BENSON.getName());
+        UnlinkCommand expectedUnlinkCommand = new UnlinkCommand(JOBFEST.getName(), contactNameList);
+
+        assertParseSuccess(parser, " " + EventUtil.getName(JOBFEST.getName())
+                        + EventUtil.getContactName(CARL.getName()) + EventUtil.getContactName(BENSON.getName()),
+                expectedUnlinkCommand);
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnlinkCommand.MESSAGE_USAGE);
+
+        // missing contact prefix
+        assertParseFailure(parser, " " + EventUtil.getName(JOBFEST.getName())
+                + BENSON.getName().fullName, expectedMessage);
+
+        // missing event prefix
+        assertParseFailure(parser, " " + JOBFEST.getName().fullName
+                + EventUtil.getContactName(CARL.getName()), expectedMessage);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/task/DeleteTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/task/DeleteTaskCommandParserTest.java
@@ -1,0 +1,76 @@
+package seedu.address.logic.parser.task;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.task.DeleteTaskCommand.MESSAGE_USAGE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DESCRIPTION;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.event.TypicalEvents.NTU;
+import static seedu.address.testutil.task.TypicalTasks.BOOK_VENUE;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.task.DeleteTaskCommand;
+import seedu.address.model.name.Name;
+import seedu.address.model.task.Task;
+import seedu.address.model.task.TaskDescription;
+import seedu.address.testutil.task.TaskBuilder;
+
+public class DeleteTaskCommandParserTest {
+
+    private DeleteTaskCommandParser parser = new DeleteTaskCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        Task correctTask = new TaskBuilder(BOOK_VENUE).withEvent(NTU).build();
+        DeleteTaskCommand correctCommand = new DeleteTaskCommand(correctTask.getDescription(),
+                correctTask.getAssociatedEventName());
+        System.out.println(correctCommand);
+        assertParseSuccess(parser,
+                " " + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription()
+                        + " " + PREFIX_EVENT + NTU.getName(), correctCommand);
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+
+        // missing name prefix
+        assertParseFailure(parser, " " + BOOK_VENUE.getDescription() + " "
+                        + PREFIX_EVENT + NTU.getName(),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+
+        // missing event prefix
+        assertParseFailure(parser, " " + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription() + " "
+                        + NTU.getName(),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_repeatedValue_failure() {
+        // repeated name prefix
+        assertParseFailure(parser, " " + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription() + " "
+                        + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription() + " "
+                        + PREFIX_EVENT + NTU.getName(),
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TASK_DESCRIPTION));
+
+        // repeated event prefix
+        assertParseFailure(parser, " " + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription() + " "
+                        + PREFIX_EVENT + NTU.getName() + " " + PREFIX_EVENT + NTU.getName(),
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EVENT));
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, " " + PREFIX_TASK_DESCRIPTION + " "
+                        + PREFIX_EVENT + NTU.getName(),
+                TaskDescription.MESSAGE_CONSTRAINTS);
+
+        // invalid event
+        assertParseFailure(parser, " " + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription() + " "
+                        + PREFIX_EVENT,
+                Name.MESSAGE_CONSTRAINTS);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/task/MarkTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/task/MarkTaskCommandParserTest.java
@@ -1,0 +1,76 @@
+package seedu.address.logic.parser.task;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.task.MarkTaskCommand.MESSAGE_USAGE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DESCRIPTION;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.event.TypicalEvents.NTU;
+import static seedu.address.testutil.task.TypicalTasks.BOOK_VENUE;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.task.MarkTaskCommand;
+import seedu.address.model.name.Name;
+import seedu.address.model.task.Task;
+import seedu.address.model.task.TaskDescription;
+import seedu.address.testutil.task.TaskBuilder;
+
+public class MarkTaskCommandParserTest {
+
+    private MarkTaskCommandParser parser = new MarkTaskCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        Task correctTask = new TaskBuilder(BOOK_VENUE).withEvent(NTU).build();
+        MarkTaskCommand correctCommand = new MarkTaskCommand(correctTask.getDescription(),
+                correctTask.getAssociatedEventName());
+        System.out.println(correctCommand);
+        assertParseSuccess(parser,
+                " " + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription()
+                        + " " + PREFIX_EVENT + NTU.getName(), correctCommand);
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+
+        // missing name prefix
+        assertParseFailure(parser, " " + BOOK_VENUE.getDescription() + " "
+                        + PREFIX_EVENT + NTU.getName(),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+
+        // missing event prefix
+        assertParseFailure(parser, " " + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription() + " "
+                        + NTU.getName(),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_repeatedValue_failure() {
+        // repeated name prefix
+        assertParseFailure(parser, " " + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription() + " "
+                        + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription() + " "
+                        + PREFIX_EVENT + NTU.getName(),
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TASK_DESCRIPTION));
+
+        // repeated event prefix
+        assertParseFailure(parser, " " + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription() + " "
+                        + PREFIX_EVENT + NTU.getName() + " " + PREFIX_EVENT + NTU.getName(),
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EVENT));
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, " " + PREFIX_TASK_DESCRIPTION + " "
+                        + PREFIX_EVENT + NTU.getName(),
+                TaskDescription.MESSAGE_CONSTRAINTS);
+
+        // invalid event
+        assertParseFailure(parser, " " + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription() + " "
+                        + PREFIX_EVENT,
+                Name.MESSAGE_CONSTRAINTS);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/task/UnmarkTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/task/UnmarkTaskCommandParserTest.java
@@ -1,0 +1,76 @@
+package seedu.address.logic.parser.task;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.task.UnmarkTaskCommand.MESSAGE_USAGE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DESCRIPTION;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.event.TypicalEvents.NTU;
+import static seedu.address.testutil.task.TypicalTasks.BOOK_VENUE;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.task.UnmarkTaskCommand;
+import seedu.address.model.name.Name;
+import seedu.address.model.task.Task;
+import seedu.address.model.task.TaskDescription;
+import seedu.address.testutil.task.TaskBuilder;
+
+public class UnmarkTaskCommandParserTest {
+
+    private UnmarkTaskCommandParser parser = new UnmarkTaskCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        Task correctTask = new TaskBuilder(BOOK_VENUE).withEvent(NTU).build();
+        UnmarkTaskCommand correctCommand = new UnmarkTaskCommand(correctTask.getDescription(),
+                correctTask.getAssociatedEventName());
+        System.out.println(correctCommand);
+        assertParseSuccess(parser,
+                " " + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription()
+                        + " " + PREFIX_EVENT + NTU.getName(), correctCommand);
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+
+        // missing name prefix
+        assertParseFailure(parser, " " + BOOK_VENUE.getDescription() + " "
+                        + PREFIX_EVENT + NTU.getName(),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+
+        // missing event prefix
+        assertParseFailure(parser, " " + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription() + " "
+                        + NTU.getName(),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_repeatedValue_failure() {
+        // repeated name prefix
+        assertParseFailure(parser, " " + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription() + " "
+                        + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription() + " "
+                        + PREFIX_EVENT + NTU.getName(),
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TASK_DESCRIPTION));
+
+        // repeated event prefix
+        assertParseFailure(parser, " " + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription() + " "
+                        + PREFIX_EVENT + NTU.getName() + " " + PREFIX_EVENT + NTU.getName(),
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EVENT));
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, " " + PREFIX_TASK_DESCRIPTION + " "
+                        + PREFIX_EVENT + NTU.getName(),
+                TaskDescription.MESSAGE_CONSTRAINTS);
+
+        // invalid event
+        assertParseFailure(parser, " " + PREFIX_TASK_DESCRIPTION + BOOK_VENUE.getDescription() + " "
+                        + PREFIX_EVENT,
+                Name.MESSAGE_CONSTRAINTS);
+    }
+}

--- a/src/test/java/seedu/address/testutil/event/EventUtil.java
+++ b/src/test/java/seedu/address/testutil/event/EventUtil.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import seedu.address.logic.commands.event.AddEventCommand;
 import seedu.address.logic.commands.event.LinkCommand;
+import seedu.address.logic.commands.event.UnlinkCommand;
 import seedu.address.model.event.Event;
 import seedu.address.model.name.Name;
 
@@ -22,6 +23,15 @@ public class EventUtil {
      */
     public static String getLinkCommand(Name name, Name contactName) {
         return LinkCommand.COMMAND_WORD + " "
+                + getName(name)
+                + getContactName(contactName);
+    }
+
+    /**
+     * Returns a unlink command string for linking the {@code contact} to the {@code Event}.
+     */
+    public static String getUnlinkCommand(Name name, Name contactName) {
+        return UnlinkCommand.COMMAND_WORD + " "
                 + getName(name)
                 + getContactName(contactName);
     }

--- a/src/test/java/seedu/address/testutil/event/TypicalEvents.java
+++ b/src/test/java/seedu/address/testutil/event/TypicalEvents.java
@@ -2,8 +2,6 @@ package seedu.address.testutil.event;
 
 import static seedu.address.testutil.contact.TypicalContacts.ALICE;
 import static seedu.address.testutil.contact.TypicalContacts.BOB;
-import static seedu.address.testutil.task.TypicalTasks.BOOK_VENUE;
-import static seedu.address.testutil.task.TypicalTasks.ORDER_FOOD;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/seedu/address/testutil/event/TypicalEvents.java
+++ b/src/test/java/seedu/address/testutil/event/TypicalEvents.java
@@ -2,6 +2,8 @@ package seedu.address.testutil.event;
 
 import static seedu.address.testutil.contact.TypicalContacts.ALICE;
 import static seedu.address.testutil.contact.TypicalContacts.BOB;
+import static seedu.address.testutil.task.TypicalTasks.BOOK_VENUE;
+import static seedu.address.testutil.task.TypicalTasks.ORDER_FOOD;
 
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
### Fix the bug of inconsistent outcomes of link and unlink commands.
When there is a mix of valid and invalid input contacts for link and unlink commands, the valid input contacts are sometimes successfully linked to or unlinked from the event, while other times they are not. The current implementation enables the commands to have consistent outcome where all input contacts will not be linked to or unlinked from the event when there is at least one invalid input. This is done by checking the validity of input contacts before linking/unlinking any of the contacts. The error message will notify the users what the first invalid input is.

### Add testcases for unlink, delete task, mark task, unmark task commands.