### PR TITLE
Fix some minor bugs

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -36,7 +36,7 @@ import seedu.address.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(1, 3, 1, true);
+    public static final Version VERSION = new Version(1, 4, 0, true);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -184,7 +184,11 @@ public class CommandResult {
      * @return true if the current screen should remain displayed, else false
      */
     public boolean shouldStayOnScreen() {
-        return this.isSelectScreen || this.shouldRemainOnScreen;
+        if (taskDescription != null && isSelectScreen) {
+            return false;
+        } else {
+            return this.shouldRemainOnScreen;
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/event/LinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/LinkCommand.java
@@ -86,8 +86,10 @@ public class LinkCommand extends Command {
             // Update the respective filtered lists to show the components within the event
             // Flow of command should be after linking a contact to an event,
             // it goes to the selected event.
-            model.updateFilteredContactList(new ContactIsInEventPredicate(eventToLink));
-            model.updateFilteredTaskList(new TaskIsInEventPredicate(eventToLink));
+            ContactIsInEventPredicate contactListPredicate = new ContactIsInEventPredicate(eventToLink);
+            TaskIsInEventPredicate taskListPredicate = new TaskIsInEventPredicate(eventToLink);
+            model.updateFilteredContactList(contactListPredicate);
+            model.updateFilteredTaskList(taskListPredicate);
 
             return new CommandResult(String.format(MESSAGE_SUCCESS, contactNameListToLink, eventNameToLink),
                     model.getEvent(eventNameToLink), false);

--- a/src/main/java/seedu/address/logic/commands/event/UnlinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/UnlinkCommand.java
@@ -79,8 +79,10 @@ public class UnlinkCommand extends Command {
             model.switchToTagsScreen(false);
 
             eventToUnlink = model.getEvent(eventNameToUnlink);
-            model.updateFilteredContactList(new ContactIsInEventPredicate(eventToUnlink));
-            model.updateFilteredTaskList(new TaskIsInEventPredicate(eventToUnlink));
+            ContactIsInEventPredicate contactListPredicate = new ContactIsInEventPredicate(eventToUnlink);
+            TaskIsInEventPredicate taskListPredicate = new TaskIsInEventPredicate(eventToUnlink);
+            model.updateFilteredContactList(contactListPredicate);
+            model.updateFilteredTaskList(taskListPredicate);
 
             return new CommandResult(String.format(MESSAGE_SUCCESS, contactNameListToUnlink, eventNameToUnlink),
                     model.getEvent(eventNameToUnlink), false);

--- a/src/main/java/seedu/address/logic/commands/tag/FilterByTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tag/FilterByTagCommand.java
@@ -44,7 +44,6 @@ public class FilterByTagCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Contact> lastShownList = model.getFilteredContactList();
 
         if (model.isOnEventsScreen() || model.isOnTagsScreen()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CONTACT_NOT_DISPLAYED);

--- a/src/main/java/seedu/address/logic/commands/task/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/AddTaskCommand.java
@@ -83,8 +83,10 @@ public class AddTaskCommand extends Command {
             model.switchToTagsScreen(false);
 
             // Update the respective filtered lists to show the components within the event.
-            model.updateFilteredContactList(new ContactIsInEventPredicate(eventToAddIn));
-            model.updateFilteredTaskList(new TaskIsInEventPredicate(eventToAddIn));
+            ContactIsInEventPredicate contactListPredicate = new ContactIsInEventPredicate(selectedEvent);
+            TaskIsInEventPredicate taskListPredicate = new TaskIsInEventPredicate(selectedEvent);
+            model.updateFilteredContactList(contactListPredicate);
+            model.updateFilteredTaskList(taskListPredicate);
 
             return new CommandResult(String.format(MESSAGE_SUCCESS,
                     taskDescription, taskDeadline, eventToAddIn.getName()),

--- a/src/main/java/seedu/address/logic/commands/task/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/DeleteTaskCommand.java
@@ -63,8 +63,10 @@ public class DeleteTaskCommand extends Command {
         model.switchToTagsScreen(false);
 
         // Update the respective filtered lists to show the components within the event
-        model.updateFilteredContactList(new ContactIsInEventPredicate(eventToDeleteTask));
-        model.updateFilteredTaskList(new TaskIsInEventPredicate(eventToDeleteTask));
+        ContactIsInEventPredicate contactListPredicate = new ContactIsInEventPredicate(eventToDeleteTask);
+        TaskIsInEventPredicate taskListPredicate = new TaskIsInEventPredicate(eventToDeleteTask);
+        model.updateFilteredContactList(contactListPredicate);
+        model.updateFilteredTaskList(taskListPredicate);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, taskDescription, associatedEventName),
                 taskDescription, eventToDeleteTask, true);

--- a/src/main/java/seedu/address/logic/commands/task/MarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/MarkTaskCommand.java
@@ -69,8 +69,10 @@ public class MarkTaskCommand extends Command {
         model.switchToTagsScreen(false);
 
         // Update the respective filtered lists to show the components within the event
-        model.updateFilteredTaskList(new TaskIsInEventPredicate(selectedEvent));
-        model.updateFilteredContactList(new ContactIsInEventPredicate(selectedEvent));
+        TaskIsInEventPredicate taskListPredicate = new TaskIsInEventPredicate(selectedEvent);
+        ContactIsInEventPredicate contactListPredicate = new ContactIsInEventPredicate(selectedEvent);
+        model.updateFilteredTaskList(taskListPredicate);
+        model.updateFilteredContactList(contactListPredicate);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, taskDescription, associatedEventName),
                 taskDescription, selectedEvent, true);

--- a/src/main/java/seedu/address/logic/commands/task/UnmarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/UnmarkTaskCommand.java
@@ -69,8 +69,10 @@ public class UnmarkTaskCommand extends Command {
         model.switchToTagsScreen(false);
 
         // Update the respective filtered lists to show the components within the event
-        model.updateFilteredContactList(new ContactIsInEventPredicate(selectedEvent));
-        model.updateFilteredTaskList(new TaskIsInEventPredicate(selectedEvent));
+        ContactIsInEventPredicate contactListPredicate = new ContactIsInEventPredicate(selectedEvent);
+        TaskIsInEventPredicate taskListPredicate = new TaskIsInEventPredicate(selectedEvent);
+        model.updateFilteredContactList(contactListPredicate);
+        model.updateFilteredTaskList(taskListPredicate);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, taskDescription, associatedEventName),
                 taskDescription, selectedEvent, true);


### PR DESCRIPTION
* Occasional `NoSuchElementException` thrown when filtering lists due to predicate being concurrently loaded.
  * Fixed by ensuring predicate is created before updating of the filtered list.
  * How to replicate:
      * execute `view_tags` command
      * mark/unmark a task that is in an event

* Fixed bug in which the marked/unmarked task is not shown and redirected to the selected event screen when we are on a different screen (`view_contacts`, `view_events`, and `view_tags`).